### PR TITLE
Gemspec and Readme Update, Adding Coveralls and TravisCI

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm:
+  - 2.0.0
+  - 2.3.1
+script:
+  - bundle exec rspec spec

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+## How to contribute to Erlen
+
+#### Report a bug
+
+* Check [Issues](https://github.com/Hireology/erlen/issues) first to ensure
+  the bug was not already reported.
+ 
+* If not, go ahead and [open a new
+  one](https://github.com/Hireology/erlen/issues/new). Try to be specific in
+  the title and description. Include a code sample or a use case that
+  describe the problem.
+
+#### Fix a bug
+
+* Open a new GitHub pull request with the patch.
+
+* Ensure the PR description clearly describes the problem and solution.
+  Include the relevant issue number if applicable.
+
+#### New feature
+
+* Contact Erlen maintainers with feature details.
+
+* Once you receive positive feedback from us, [open a new
+  issue](https://github.com/Hireology/erlen/issues/new) with a
+  "enchancement" label.
+
+* Start coding!
+
+Thanks!
+
+Hireology

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec
+gem 'coveralls', require: false, group: :test
+gem 'simplecov', require: false, group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,51 @@
+PATH
+  remote: .
+  specs:
+    erlen (0.0.10)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coveralls (0.8.16)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.12.0)
+      term-ansicolor (~> 1.3.0)
+      thor (~> 0.19.1)
+      tins (>= 1.6.0, < 2)
+    diff-lcs (1.2.5)
+    docile (1.1.5)
+    json (2.0.2)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    simplecov (0.12.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
+    term-ansicolor (1.3.2)
+      tins (~> 1.0)
+    thor (0.19.4)
+    tins (1.13.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  coveralls
+  erlen!
+  rspec (~> 3.1)
+  simplecov
+
+BUNDLED WITH
+   1.13.0

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Erlen
 
-Erlen is short for Erlenmeyer, a type of laboratory flask that looks like
-Hireology's logo. Erlen is a library that provides a framework for schema
-creation, validation, and serialization. A schema is a definition of a
-resource or a resource group and describes what is expected in a transaction
-regardless of the protocol--e.g., HTTP, RPC, Ruby call, and etc. In other
-words, Erlen allows you to define contracts and share them across different
-services and also enforce what is defined in the contracts.
+Erlen is short for
+[Erlenmeyer](https://en.wikipedia.org/wiki/Erlenmeyer_flask), a type of
+laboratory flask that looks like Hireology's logo. Erlen is a Ruby library
+that provides a framework for schema creation, validation, and
+serialization. A schema is a definition of a resource or a resource group
+and describes what is expected in a transaction regardless of the
+protocol--e.g., HTTP, RPC, Ruby call, and etc.  In other words, Erlen allows
+you to define contracts and share them across different services and also
+enforce what is defined in the contracts.
 
 ## Installation
 
@@ -14,22 +16,26 @@ TBD
 
 ## Definitions
 
+For convenience, let's define a few terms we will be using throughout this
+documentation.
+
 ### Schema
 
-A formal contract between two parties, defined with a set of of attributes
-and validations. It is represented as a class which inherits from
-`Erlen::Schema::Base`. Note that a schema is a _portable_ definition so there
-is no business logic within a schema.
+A formal contract between two or more parties, defined with a set of of
+attributes and validations. It is represented as a class which inherits from
+`Erlen::Schema::Base`. Note that a schema is a _portable_ definition so
+there is no business logic embedded within a schema.
 
 ### Attribute
 
-A property defined within a schema. Zero or more attributes can be defined
-in a schema.
+A property defined in a schema. Zero or more attributes can be defined in a
+schema. An attribute is defined with a unique name, a type, and various
+options.
 
 ### Payload
 
 Also called a _schema object_. An instance of `Erlen::Schema::Base` or its
-descendents with actual data.
+descendent with actual data.
 
 ## Usage
 
@@ -37,30 +43,60 @@ It's easy to use Erlen. In a typical Rails application, you will define a
 set of schemas and configure controllers to specify action and schema
 associations. Let's look at how one can define a schema.
 
-### Define a Schema
-
-In order to define a schema, just inherit from `Erlen::Schema::Base`. For
-example, a user schema can be defined as the following:
+In order to define a schema, just create a class that inherits from
+`Erlen::Schema::Base` or any of its descendents. For example, a user schema
+can be defined as the following:
 
     class UserSchema < Erlen::Schema::Base
       attribute :name, String, required: true { |a| a.length > 5 }
       attribute :email, String, required: true
       attribute :nickname, String, required: false
       attribute :organization, OrganizationSchema, required: true
-
-      validate { |payload| payload.name != "fake" }
+      validate { |payload| payload.name != payload.email }
     end
 
-An attribute can be defined with a name, type, validation, and options.
-Name and type are required. A type can be one of the primitive types
-(String, Numeric, Integer, and Boolean) or a schema. Currently options
-include `required`, which makes the attribute a required attribute, and
-`alias`, which is used to make alias for importing from an object. The
-validation block can be optionally given to perform an attribute-specific
-validation.  The schema itself can have custom validation code aside from
-basic type checks and attribute-specific validations.
+### Attribute
 
-### Instantiate a Schema
+An attribute can be defined with a name, a type, various options, and
+an attribute-specific validation. The name and type must be specified.
+A type can be either a primitive Ruby type or a schema.
+
+Here are primitive types that are supported:
+
+* String
+* Numberic (Float, Integer, and etc.)
+* Boolean (TrueClass, FalseClass)
+* DateTime
+
+Note that their subclasses are also supported whereas schema types must
+match exactly. (More explained later.)
+
+Currently, options include
+
+* required: this option flag makes the attribute a required attribute for
+  the schema. By default, this option is set to false.
+* alias: this option allows schema to also look into alias for importing
+  or initialialization.
+* default: if this option is specified, the value will be used as a default
+  value if the corresponding attribute value is missing from the source
+  data.
+
+A validation block can be specified to perform an attribute-specific
+validation (as opposed to schema-wide validation).
+
+### Validation
+
+A schema can have zero or more custom validation code. Each validation is
+represented with a code block, and the payload is passed in as the block
+argument.
+
+For example,
+
+      validate { |payload| payload.name != payload.nickname }
+
+ensures that the payload's name and nickname do not match.
+
+### Instantiation
 
 By instantiating the user schema, you get a user payload.
 
@@ -73,57 +109,67 @@ By instantiating the user schema, you get a user payload.
         }
     )
 
-You may pass in a hash object from which attributes will be populated. If
-you are using this method, the initial object must be a hash and it must not
-contain any attribute that is not defined in the schema. Otherwise,
-`Erlen::NoAttributeError` will be thrown.
+For convenience, you may pass in a hash object from which attributes will be
+assigned. If you are using this method, the initial object must be a hash
+object that does not contain any attribute that is not defined in the
+schema. Otherwise, an `Erlen::NoAttributeError` will be thrown.
+
+### Importing
 
 Alternatively, you may use `import` method instead:
 
     user_payload = UserSchema.import(user)
 
-User can be any object (including a payload) possibly with some attributes
-populated. This method is more graceful than the former that any undefined
+User can be _any_ object (including a payload) possibly with some attributes
+populated. This method is more graceful than the former since any undefined
 attributes from the source object will be simply ignored. It will be
 particularly useful to import data from an active record object, for
 example.
 
 ### Pre-defined Schemas
 
-For your convenience, there are several pre-defined schemas (under `Erlen`
-namespace):
+For your convenience, Erlen is shipped with pre-defined schemas (under
+`Erlen::Schema` namespace):
 
-* `EmptySchema`: there is nothing in this schema. It will only match empty
-payload.
-* `AnySchema`: this is a special schema definition that allows _any_
-payload
-* `ResourceSchema`: This schema represents a resource payload which includes
-`id` and timestamp fields, `created_at` and `updated_at`.
-* `AnyOf`: This allows any payload whose schema is one of the specified
-schemas.
-* `ArrayOf`: This schema represents a list of payloads of the specified
-type.
-* `ResourceListOf`: Similar to `ArrayOf` but has a structure as defined in
-our API standard.
+* `Erlen::Schema::Empty` has nothing. It will only match empty payload.
+* `Erlen::Schema::Any`  is a special schema definition that allows _any_
+  payload. No validation will occur.
+* `Erlen::Schema::Resource` represents a _resource_ payload, as defined in
+  Hireology API Standards.
 
-Note that `AnyOf` and `ArrayOf` are like functors (as in OCaml) that
-dynamically generates a concrete class based on additional type information.
+### Schema Generators
+
+Erlen also includes a few schema generators. They are like functors (as in
+OCaml) that dynamically generate classes based on additional type
+information. Here is the list of schema generators:
+
+* `Erlen::Schema::AnyOf` can generate a schema that can represent one or
+  more schemas. The payload of the generated schema can be any of the
+  specified schemas.
+* `Erlen::Schema::ArrayOf` can generate a schema that contains multiple
+  elements of the specified type (which can be either a primitive or
+  schema).
+* `Erlen::Schema::ResourceArrayOf`: Similar to `ArrayOf` but the generated
+  schema has a resource list structure, as defined in Hireology API
+  Standards.
+
 For instance,
 
     AnyOf.new(DogSchema, CatSchema)
 
-can allow either a dog payload or a cat payload.
+generates a schema whose payload can be either a dog or a cat.
+
+Consider another example:
 
     ArrayOf.new(Integer)
 
-The above example restricts elements to be integers. The elements can be
-accessed via `element` method.
+This generates a schema that works as an array of `Integer`s. The generated
+schema has a set of Array operators as well:
 
     ints = ArrayOf.new(Integer)
-    ints.elements << 1
-    ints.elements << 2
-    ints.elements
-    # will return [1, 2]
+    ints << 1
+    ints << 2
+    x = ints[0] # 1
 
 ### ControllerHelper
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,15 @@ In order to define a schema, just create a class that inherits from
 `Erlen::Schema::Base` or any of its descendents. For example, a user schema
 can be defined as the following:
 
-    class UserSchema < Erlen::Schema::Base
-      attribute :name, String, required: true { |a| a.length > 5 }
-      attribute :email, String, required: true
-      attribute :nickname, String, required: false
-      attribute :organization, OrganizationSchema, required: true
-      validate { |payload| payload.name != payload.email }
-    end
+```ruby
+class UserSchema < Erlen::Schema::Base
+  attribute :name, String, required: true { |a| a.length > 5 }
+  attribute :email, String, required: true
+  attribute :nickname, String, required: false
+  attribute :organization, OrganizationSchema, required: true
+  validate { |payload| payload.name != payload.nickname }
+end
+```
 
 ### Attribute
 
@@ -66,21 +68,21 @@ A type can be either a primitive Ruby type or a schema.
 
 Here are primitive types that are supported:
 
-* String
-* Numberic (Float, Integer, and etc.)
-* Boolean (TrueClass, FalseClass)
-* DateTime
+* `String`
+* `Numeric` (Float, Integer, and etc.)
+* `Boolean` (TrueClass, FalseClass)
+* `DateTime`
 
 Note that their subclasses are also supported whereas schema types must
 match exactly. (More explained later.)
 
 Currently, options include
 
-* required: this option flag makes the attribute a required attribute for
+* `required`: this option flag makes the attribute a required attribute for
   the schema. By default, this option is set to false.
-* alias: this option allows schema to also look into alias for importing
+* `alias`: this option allows schema to also look into alias for importing
   or initialialization.
-* default: if this option is specified, the value will be used as a default
+* `default`: if this option is specified, the value will be used as a default
   value if the corresponding attribute value is missing from the source
   data.
 
@@ -95,7 +97,9 @@ argument.
 
 For example,
 
-      validate { |payload| payload.name != payload.nickname }
+```ruby
+validate { |payload| payload.name != payload.nickname }
+```
 
 ensures that the payload's name and nickname do not match.
 
@@ -103,14 +107,16 @@ ensures that the payload's name and nickname do not match.
 
 By instantiating the user schema, you get a user payload.
 
-    user_payload = UserSchema.new(
-        name: "Joe Smith",
-        email: "joe@smith.com",
-        organization: {
-          id: 1,
-          name: "Hireology"
-        }
-    )
+```ruby
+user_payload = UserSchema.new(
+    name: "Joe Smith",
+    email: "joe@smith.com",
+    organization: {
+      id: 1,
+      name: "Hireology"
+    }
+)
+```
 
 For convenience, you may pass in a hash object from which attributes will be
 assigned. If you are using this method, the initial object must be a hash
@@ -121,7 +127,9 @@ schema. Otherwise, an `Erlen::NoAttributeError` will be thrown.
 
 Alternatively, you may use `import` method instead:
 
-    user_payload = UserSchema.import(user)
+```ruby
+user_payload = UserSchema.import(user)
+```
 
 User can be _any_ object (including a payload) possibly with some attributes
 populated. This method is more graceful than the former since any undefined
@@ -158,52 +166,60 @@ information. Here is the list of schema generators:
 
 For instance,
 
-    AnyOf.new(DogSchema, CatSchema)
+```ruby
+AnyOf.new(DogSchema, CatSchema)
+```
 
 generates a schema whose payload can be either a dog or a cat.
 
 Consider another example:
 
-    ArrayOf.new(Integer)
+```ruby
+ArrayOf.new(Integer)
+```
 
 This generates a schema that works as an array of `Integer`s. The generated
 schema has a set of Array operators as well:
 
-    ints = ArrayOf.new(Integer)
-    ints << 1
-    ints << 2
-    x = ints[0] # 1
+```ruby
+ints = ArrayOf.new(Integer)
+ints << 1
+ints << 2
+x = ints[0] # 1
+```
 
 ### ControllerHelper
 
 Erlen is shipped with a Rails helper called `Erlen::Rails::ControllerHelper` which
 can be included in a controller to associate actions with schemas.
 
-    class UsersController < ApplicationConroller
-      include Erlen::Rails::ControllerHelper
+```ruby
+class UsersController < ApplicationConroller
+  include Erlen::Rails::ControllerHelper
 
-      action_schema :index, response: ResourceListOfUsersSchema
-      action_schema :create, request: UserCreateRequestSchema, response: UserResponseSchema
-      action_schema :update, request: UserUpdateRequestSchema, response: UserResponseSchema
-      action_schema :show, response: UserResponseSchema
+  action_schema :index, response: ResourceListOfUsersSchema
+  action_schema :create, request: UserCreateRequestSchema, response: UserResponseSchema
+  action_schema :update, request: UserUpdateRequestSchema, response: UserResponseSchema
+  action_schema :show, response: UserResponseSchema
 
-      def create
-        # ...
-      end
+  def create
+    # ...
+  end
 
-      def update
-        # ...
-      end
+  def update
+    # ...
+  end
 
-      def show
-        # ...
-      end
+  def show
+    # ...
+  end
 
-      def destroy
-        # ...
-      end
+  def destroy
+    # ...
+  end
 
-    end
+end
+```
 
 It is important to note that the above example used slightly different
 schemas for different actions and between requests and response. This is
@@ -218,10 +234,12 @@ before the specified action to validate the raw request body and hydrate the
 data into a payload. By defining a response schema, another callback is
 registered to perform a validation on the response body.
 
-For your convenience, `Erlen::Rails::ControllerHelper` overloads `render`
+For your convenience, `Erlen::Rails::ControllerHelper` overrides `render`
 method so you can easily render a payload.
 
-    render(payload: user_payload, status: 200)
+```ruby
+render(payload: user_payload, status: 200)
+```
 
 This is not required, however. The advantage of using the above method is
 (1) you don't need to serialize the payload into JSON yourself, and (2)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/Hireology/erlen.svg?branch=master)](https://travis-ci.org/Hireology/erlen)
+[![Coverage Status](https://coveralls.io/repos/github/Hireology/erlen/badge.svg?branch=master)](https://coveralls.io/github/Hireology/erlen)
+
 # Erlen
 
 Erlen is short for

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Currently, options include
 A validation block can be specified to perform an attribute-specific
 validation (as opposed to schema-wide validation).
 
+Note that validation is not completely portable. So keep in mind that custom
+validations may not be strictly enforced in other platforms.
+
 ### Validation
 
 A schema can have zero or more custom validation code. Each validation is
@@ -102,6 +105,9 @@ validate { |payload| payload.name != payload.nickname }
 ```
 
 ensures that the payload's name and nickname do not match.
+
+Note that validation is not completely portable. So keep in mind that custom
+validations may not be strictly enforced in other platforms.
 
 ### Instantiation
 

--- a/erlen.gemspec
+++ b/erlen.gemspec
@@ -1,16 +1,22 @@
+$:.push File.expand_path("../lib", __FILE__)
+
+require 'erlen/version'
+
 Gem::Specification.new do |s|
   s.name        = 'erlen'
-  s.version     = '0.0.10'
-  s.date        = '2016-10-21'
-  s.summary     = 'VALIDATE'
-  s.description = 'Validator and Serializer'
+  s.version     = Erlen::VERSION
+  s.summary     = 'Ruby library for JSON schema creation, validation, and serialization'
+  s.description = 'Erlen is a Ruby library for JSON schema creation, validation, and serialization.'
   s.authors     = ['Tim Brenner', 'David An']
+  s.email       = [
+    'engineering@hireology.com',
+    'timpbrenner@gmail.com',
+    'davidan1981@gmail.com'
+  ]
   s.platform    = Gem::Platform::RUBY
-  s.files       = Dir['lib/*']
+  s.files       = Dir['lib/**/*', 'MIT-LICENSE', 'README.md']
   s.license     = 'MIT'
-  s.email       = 'engineering@hireology.com'
+  s.homepage    = 'https://github.com/Hireology/erlen'
 
-  #s.homepage    = 'http://rubygems.org/gems/hola'
-
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec', '~> 3.1'
 end

--- a/lib/erlen/schema/base.rb
+++ b/lib/erlen/schema/base.rb
@@ -143,7 +143,7 @@ module Erlen; module Schema
       if mname.to_s.end_with?('=')
         __assign_attribute(mname[0..-2].to_sym, value)
       else
-        __find_attribute_value_by_name(mname.to_sym) || (raise NoAttributeError.new(mname))
+        __find_attribute_value_by_name(mname.to_sym)
       end
     end
 
@@ -211,10 +211,12 @@ module Erlen; module Schema
     end
 
     def __find_attribute_value_by_name(name)
-      @attributes[name] ||
-        self.class.schema_attributes.each_pair do |k, attr|
-          return @attributes[k] if attr.options[:alias] == name
-        end
+      name = name.to_sym
+      return @attributes[name] if @attributes.include?(name)
+      self.class.schema_attributes.each_pair do |k, attr|
+        return @attributes[k] if attr.options[:alias] == name
+      end
+      raise NoAttributeError.new(name)
     end
 
   end

--- a/lib/erlen/version.rb
+++ b/lib/erlen/version.rb
@@ -1,0 +1,3 @@
+module Erlen
+  VERSION = "0.0.10"
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,17 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
+require 'simplecov'
+require 'coveralls'
+
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+])
+SimpleCov.start do
+  add_filter '/spec/'
+end
+
 require_relative '../lib/erlen'
 
 RSpec.configure do |config|


### PR DESCRIPTION
The only fix included in this PR is how we retrieve an attribute value from a payload. Since the value can be nil, we only raise the exception after lookup attempts were made instead of looking at the value of the attribute (which can be legitimately nil).