### PR TITLE
Update Attribute Validation Syntax Example In README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ can be defined as the following:
 
 ```ruby
 class UserSchema < Erlen::Schema::Base
-  attribute :name, String, required: true { |a| a.length > 5 }
+  attribute :name, String, { required: true } { |a| a.length > 5 }
   attribute :email, String, required: true
   attribute :nickname, String, required: false
   attribute :organization, OrganizationSchema, required: true


### PR DESCRIPTION
current attribute validation syntax example in the readme is incorrect.  this PR provides an updated example.