### PR TITLE
AnyOf Schema Fix, Renames

### DIFF
--- a/lib/erlen/schema/any_of.rb
+++ b/lib/erlen/schema/any_of.rb
@@ -29,6 +29,10 @@ module Erlen; module Schema
             new(hash)
           end
 
+          def schema_of?(payload)
+            super(payload) || allowed_schemas.select {|schema| schema.schema_of?(payload)}.length > 0
+          end
+
         end
 
         klass.allowed_schemas = allowed_schemas
@@ -57,11 +61,6 @@ module Erlen; module Schema
           @payload.method_missing(mname, value)
         end
 
-        def to_hash
-          warn "[DEPRECATION] `to_hash` is deprecated.  Please use `to_data` instead."
-          to_data
-        end
-
         def to_data
           @payload.to_data
         end
@@ -72,8 +71,11 @@ module Erlen; module Schema
         def __matched_schema_payload(hash)
           self.class.allowed_schemas.each do |s|
             begin
-              @payload = s.new(hash)
-              break
+              payload = s.new(hash)
+              if payload.valid?
+                @payload = payload
+                break
+              end
             rescue
               # nothing
             end

--- a/lib/erlen/schema/base.rb
+++ b/lib/erlen/schema/base.rb
@@ -89,6 +89,11 @@ module Erlen; module Schema
         klass.validator_procs = procs
       end
 
+      # Determines whether payload is an instance of this schema.
+      def schema_of?(payload)
+        self == payload.class
+      end
+
     end
 
     # There are two ways to initialize a payload: (1) by specifying a Hash
@@ -127,14 +132,13 @@ module Erlen; module Schema
 
     # Determines if the payload is an instance of the specified schema
     # class. This overrides Object#is_a? so subclassing is not considered
-    # true.
-    #
-    # TODO: we may have to dig more into how is_a? is really implemented.
+    # true. The logic is actually implemented in ::Base.schema_of?:: method
+    # so a concrete schema can implement more precise logic.
     #
     # @param klass [Class] a schema class
     # @return [Boolean] true if payload is considered of the specified type.
     def is_a?(klass)
-      klass == self.class
+      klass.schema_of?(self) if klass <= Base
     end
 
     def method_missing(mname, value=nil)
@@ -151,6 +155,7 @@ module Erlen; module Schema
     # @return [Hash] the payload data
     def to_hash
       warn "[DEPRECATION] `to_hash` is deprecated.  Please use `to_data` instead."
+      warn "  #{caller_locations(1).first}"
       to_data
     end
 

--- a/lib/erlen/serializer/base.rb
+++ b/lib/erlen/serializer/base.rb
@@ -1,29 +1,36 @@
 module Erlen; module Serializer
   class Base
-    def self.hash_to_payload(data, schemaClass)
-      data = convert_hash_keys(data)
 
-      schemaClass.new(data)
+    def self.hash_to_payload(data, schema)
+      warn "[DEPRECATION] `hash_to_payload` is deprecated.  Please use `data_to_payload` instead."
+      warn "  #{caller_locations(1).first}"
+      data_to_payload(data, schema)
+    end
+
+    def self.data_to_payload(data, schema)
+      data = convert_data(data)
+      schema.new(data)
     end
 
     def self.payload_to_hash(payload)
+      warn "[DEPRECATION] `payload_to_hash` is deprecated.  Please use `payload_to_data` instead."
+      warn "  #{caller_locations(1).first}"
       payload_to_data(payload)
     end
 
     def self.payload_to_data(payload)
       return nil unless payload.valid?
-
       payload.to_data
     end
 
     private
 
-    def self.convert_hash_keys(value)
+    def self.convert_data(value)
       case value
       when Array
-        value.map { |v| convert_hash_keys(v) }
+        value.map { |v| convert_data(v) }
       when Hash
-        Hash[value.map { |k, v| [underscore(k.to_s).to_sym, convert_hash_keys(v)] }]
+        Hash[value.map { |k, v| [underscore(k.to_s).to_sym, convert_data(v)] }]
       else
         value
       end

--- a/lib/erlen/serializer/json.rb
+++ b/lib/erlen/serializer/json.rb
@@ -5,7 +5,7 @@ module Erlen; module Serializer
   class JSON < Base
     def self.from_json(json, schema_class)
       data = ::JSON.parse(json)
-      hash_to_payload(data, schema_class)
+      data_to_payload(data, schema_class)
     end
 
     def self.to_json(payload)

--- a/lib/erlen/serializer/json.rb
+++ b/lib/erlen/serializer/json.rb
@@ -3,9 +3,9 @@ require_relative 'base'
 
 module Erlen; module Serializer
   class JSON < Base
-    def self.from_json(json, schema_class)
+    def self.from_json(json, schema)
       data = ::JSON.parse(json)
-      data_to_payload(data, schema_class)
+      data_to_payload(data, schema)
     end
 
     def self.to_json(payload)

--- a/spec/erlen/schema/base_spec.rb
+++ b/spec/erlen/schema/base_spec.rb
@@ -75,7 +75,7 @@ describe Erlen::Schema::Base do
       expect(data['custom']).to eq(nil)
     end
 
-    it 'converts to hash' do
+    it 'converts to data' do
       payload = TestBaseSchema.import(TestObj.new)
       data = payload.to_data
 

--- a/spec/erlen/schema/schemas_spec.rb
+++ b/spec/erlen/schema/schemas_spec.rb
@@ -64,6 +64,8 @@ describe Erlen::Schema::AnyOf do
     it "validates as long as one schema matches" do
       dog = Dog.new(woof: true)
       expect(dog.valid?).to be_truthy
+      expect(dog.is_a? DogOrCat).to be_truthy
+      expect(dog.is_a? Cat).to be_falsey
       dog_or_cat = DogOrCat.import(dog)
       expect(dog_or_cat.is_a? DogOrCat).to be_truthy
       expect(dog_or_cat.is_a? Dog).to be_truthy

--- a/spec/erlen/schema/schemas_spec.rb
+++ b/spec/erlen/schema/schemas_spec.rb
@@ -65,6 +65,7 @@ describe Erlen::Schema::AnyOf do
       dog = Dog.new(woof: true)
       expect(dog.valid?).to be_truthy
       dog_or_cat = DogOrCat.import(dog)
+      expect(dog_or_cat.is_a? DogOrCat).to be_truthy
       expect(dog_or_cat.is_a? Dog).to be_truthy
       expect(dog_or_cat.is_a? Cat).to be_falsey
       expect(dog_or_cat.is_a? Cow).to be_falsey
@@ -75,6 +76,9 @@ describe Erlen::Schema::AnyOf do
     end
     it "validates optional schema" do
       cow_or_nothing = CowOrNothing.new({})
+      expect(cow_or_nothing.is_a? CowOrNothing).to be_truthy
+      expect(cow_or_nothing.is_a? Cow).to be_falsey
+      expect(cow_or_nothing.is_a? Erlen::Schema::Empty).to be_truthy
       expect(cow_or_nothing).to be_truthy
       cow = Cow.new(moo: true)
       cow_or_nothing = CowOrNothing.import(cow)

--- a/spec/erlen/serializer/base_spec.rb
+++ b/spec/erlen/serializer/base_spec.rb
@@ -4,9 +4,18 @@ describe Erlen::Serializer::Base do
   subject { described_class }
 
   describe "#data_to_payload" do
-    it "sets all the values" do
+    it "sets all the values from hash" do
       data = { foo: 'bar' }
       payload = subject.hash_to_payload(data, TestBaseSerializerSchema)
+
+      expect(payload.is_a? TestBaseSerializerSchema).to be_truthy
+      expect(payload.foo).to eq('bar')
+      expect(payload.valid?).to be_truthy
+    end
+
+    it "sets all the values" do
+      data = { foo: 'bar' }
+      payload = subject.data_to_payload(data, TestBaseSerializerSchema)
 
       expect(payload.is_a? TestBaseSerializerSchema).to be_truthy
       expect(payload.foo).to eq('bar')


### PR DESCRIPTION
Two changes:

- `AnyOf` generated schemas will have an improved `is_a?` method.
  - In order to do this, I had to re-implement `is_a?` in the `Base` schema. Now, we are going to let the schema actually validate the payload. Why? This allows concrete schemas to define their custom type check.
  - By doing so, `AnyOf` generated schemas can compare the payload to any of the allowed schemas.
  - Also, I noticed `is_valid?` check wasn't performed during `new`. This is needed to be consistent with `import`. And this will actually fix some of the issues we were facing.
- Renamed a few things
  - Remainings of `hash` was renamed to `data`.
  - private method `render_schema` is renamed to `render_payload`. 
  - renamed `@request_payload` and `@response_payload` to `@__erlen__request_payload` and `@__erlen__response_payload`.

Added more test cases to cover all the changes mentioned in this PR.

Ah, also, I added the caller location to the warning we generate for deprecated stuff.