### PR TITLE
Add equality comparison methods

### DIFF
--- a/lib/erlen/schema/base.rb
+++ b/lib/erlen/schema/base.rb
@@ -144,7 +144,7 @@ module Erlen; module Schema
     # Checks if a payload is equal to another by ensuring they are of the
     # same class and contain the same data.
     def ==(other)
-      other.class == self.class && other.to_data == to_data
+      other.is_a?(self.class) && other.to_data == to_data
     end
 
     # Checks if payloads refer to the same hash key. It is common for

--- a/lib/erlen/schema/base.rb
+++ b/lib/erlen/schema/base.rb
@@ -141,6 +141,16 @@ module Erlen; module Schema
       klass.schema_of?(self) if klass <= Base
     end
 
+    # Checks if a payload is equal to another by ensuring they are of the
+    # same class and contain the same data.
+    def ==(other)
+      other.class == self.class && other.to_data == to_data
+    end
+
+    # Checks if payloads refer to the same hash key. It is common for
+    # classes that override #== to also alias #eql? thusly.
+    alias eql? ==
+
     def method_missing(mname, value=nil)
       if mname.to_s.end_with?('=')
         __assign_attribute(mname[0..-2].to_sym, value)

--- a/spec/erlen/schema/any_of_spec.rb
+++ b/spec/erlen/schema/any_of_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe Erlen::Schema::AnyOf do
+  subject { described_class }
+  let(:any_of_1) { subject.new(TestAnyASchema, TestAnyBSchema) }
+  let(:any_of_2) { subject.new(TestAnyASchema, TestAnyBSchema) }
+
+  describe '#==' do
+    it 'is equal to another of the same class and data' do
+      payload1 = any_of_1.import(foo: 'bar', custom: 'v1')
+      payload2 = any_of_1.import(foo: 'bar', custom: 'v1')
+
+      expect(payload1 == payload2).to be(true)
+    end
+
+    it 'is equal to another AnyOf of the same class and data' do
+      payload1 = any_of_1.import(foo: 'bar', custom: 'v1')
+      payload2 = any_of_2.import(foo: 'bar', custom: 'v1')
+
+      expect(payload1 == payload2).to be(true)
+    end
+
+    it 'is equal to another of the same concrete schema and data' do
+      payload1 = any_of_1.import(foo: 'bar', custom: 'v1')
+      payload2 = TestAnyASchema.import(foo: 'bar', custom: 'v1')
+
+      expect(payload1 == payload2).to be(true)
+      expect(payload2 == payload1).to be(true)
+    end
+
+    it 'is not equal to another if they differ in data' do
+      payload1 = any_of_1.import(foo: 'bar', custom: 'v1')
+      payload2 = any_of_1.import(foo: 'bar', custom: 'v2')
+
+      expect(payload1 == payload2).to be(false)
+    end
+
+    it 'is not equal to another if they differ in class' do
+      payload1 = any_of_1.import(foo: 'bar', custom: 'v1')
+      payload2 = any_of_1.import(bar: 1, buzz: 'world')
+
+      expect(payload1 == payload2).to be(false)
+    end
+  end
+end
+
+class TestAnyASchema < Erlen::Schema::Base
+  attribute :foo, String
+  attribute :custom, String
+end
+
+class TestAnyBSchema < Erlen::Schema::Base
+  attribute :bar, Integer
+  attribute :buzz, String
+end

--- a/spec/erlen/schema/base_spec.rb
+++ b/spec/erlen/schema/base_spec.rb
@@ -83,6 +83,52 @@ describe Erlen::Schema::Base do
       expect(data['custom']).to eq(nil)
     end
   end
+
+  describe '#==' do
+    it 'is equal to another of the same class and data' do
+      payload1 = TestBaseSchema.import(foo: 'bar', custom: 1)
+      payload2 = TestBaseSchema.import(foo: 'bar', custom: 1)
+
+      expect(payload1 == payload2).to be(true)
+    end
+
+    it 'is not equal to another if they differ in data' do
+      payload1 = TestBaseSchema.import(foo: 'bar', custom: 1)
+      payload2 = TestBaseSchema.import(foo: 'baz', custom: 1)
+
+      expect(payload1 == payload2).to be(false)
+    end
+
+    it 'is not equal to another if they differ in class' do
+      payload1 = TestBaseSchema.import(foo: 'bar', custom: 1)
+      payload2 = TestSubSchema.import(foo: 'bar', custom: 1)
+
+      expect(payload1 == payload2).to be(false)
+    end
+  end
+
+  describe '#eql?' do
+    it 'is equal to another of the same class and data' do
+      payload1 = TestBaseSchema.import(foo: 'bar', custom: 1)
+      payload2 = TestBaseSchema.import(foo: 'bar', custom: 1)
+
+      expect(payload1.eql?(payload2)).to be(true)
+    end
+
+    it 'is not equal to another if they differ in data' do
+      payload1 = TestBaseSchema.import(foo: 'bar', custom: 1)
+      payload2 = TestBaseSchema.import(foo: 'baz', custom: 1)
+
+      expect(payload1.eql?(payload2)).to be(false)
+    end
+
+    it 'is not equal to another if they differ in class' do
+      payload1 = TestBaseSchema.import(foo: 'bar', custom: 1)
+      payload2 = TestSubSchema.import(foo: 'bar', custom: 1)
+
+      expect(payload1.eql?(payload2)).to be(false)
+    end
+  end
 end
 
 class TestBaseSchema < Erlen::Schema::Base
@@ -96,4 +142,7 @@ class TestObj
   def bar
     'bar'
   end
+end
+
+class TestSubSchema < TestBaseSchema
 end


### PR DESCRIPTION
The Erlen::Schema::Base class did not override the equality comparison method `==`, defaulting to `Object#==` which tests for object reference equality. This PR defines a meaningful equality comparison in `==` and aliases `eql?`to it.