### PR TITLE
to_data will exclude keys of undefined values. Add deep_clone() method

### DIFF
--- a/lib/erlen/rails/controller_helper.rb
+++ b/lib/erlen/rails/controller_helper.rb
@@ -101,15 +101,13 @@ module Erlen; module Rails
     # request body or response body, validated against the schema. This
     # particular method is only used to retrieve the request payload.
     def request_payload
-      # raise NoPayloadError if @__erlen__request_payload.nil?
-      @request_schema.import(@__erlen__request_payload) if @__erlen__request_payload
+      @__erlen__request_payload.deep_clone if @__erlen__request_payload
     end
 
     # Reads the current response payload, an instance of Schema::Base class.
     # You can set this value using render().
     def response_payload
-      # raise NoPayloadError if @__erlen__response_payload.nil?
-      @response_schema.import(@__erlen__response_payload) if @__erlen__response_payload
+      @__erlen__response_payload.deep_clone if @__erlen__response_payload
     end
 
     private

--- a/spec/erlen/schema/base_spec.rb
+++ b/spec/erlen/schema/base_spec.rb
@@ -82,6 +82,13 @@ describe Erlen::Schema::Base do
       expect(data['foo']).to eq('bar')
       expect(data['custom']).to eq(nil)
     end
+
+    it 'does not include undefined attribute' do
+      payload = TestBaseSchema.new()
+      data = payload.to_data
+      expect(data.include?('foo')).to be_falsey
+      expect(data.include?('custom')).to be_falsey
+    end
   end
 
   describe '#==' do


### PR DESCRIPTION
This is more consistent than what we used to do (which is assign nil).
Also, controller helper will use deep_clone method to copy the original
payload.