### PR TITLE
add as_json to Erlen::Schema::Base

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    erlen (0.1.5)
+    erlen (0.1.8)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/erlen/rails/controller_helper.rb
+++ b/lib/erlen/rails/controller_helper.rb
@@ -1,3 +1,6 @@
+require 'active_support'
+require 'action_controller'
+
 module Erlen; module Rails
   # This helper module can be included in a controller to define action
   # schemas, which creates before/after action callbacks to validate

--- a/lib/erlen/schema/base.rb
+++ b/lib/erlen/schema/base.rb
@@ -194,6 +194,10 @@ module Erlen; module Schema
       Hash[arr]
     end
 
+    def as_json(*args)
+      to_data.as_json(*args)
+    end
+
     # Performs a deep cloning of the current payload. It's cloning and not
     # importing so undefined values will remain undefined.
     #

--- a/spec/erlen/schema/base_spec.rb
+++ b/spec/erlen/schema/base_spec.rb
@@ -157,6 +157,15 @@ describe Erlen::Schema::Base do
       expect(payload1.eql?(payload2)).to be(false)
     end
   end
+
+  describe '#as_json' do
+    it 'uses the hash of to_data for json conversion' do
+      payload = TestBaseSchema.import(foo: 'bar', custom: 1)
+
+      expect(payload).not_to receive(:warn)
+      expect(payload.to_hash).to eq(foo: 'bar', custom: 1)
+    end
+  end
 end
 
 class TestBaseSchema < Erlen::Schema::Base

--- a/spec/erlen/schema/base_spec.rb
+++ b/spec/erlen/schema/base_spec.rb
@@ -163,7 +163,14 @@ describe Erlen::Schema::Base do
       payload = TestBaseSchema.import(foo: 'bar', custom: 1)
 
       expect(payload).not_to receive(:warn)
-      expect(payload.to_hash).to eq(foo: 'bar', custom: 1)
+      expect(payload.as_json).to eq('foo' => 'bar', 'custom' => 1)
+    end
+
+    it 'filters by using activesupport Hash modifications' do
+      payload = TestBaseSchema.import(foo: 'bar', custom: 1)
+
+      expect(payload).not_to receive(:warn)
+      expect(payload.as_json(only: 'foo')).to eq('foo' => 'bar')
     end
   end
 end


### PR DESCRIPTION
Implement `as_json` method on Erlen::Schema::Base. This method would be a good candidate to move to a future "erlen-rails" gem.
