### PR TITLE
Respect hash value defaults in schema imports

### DIFF
--- a/lib/erlen/schema/base.rb
+++ b/lib/erlen/schema/base.rb
@@ -60,7 +60,7 @@ module Erlen; module Schema
           obj_attribute_name = (attr.options[:alias] || attr.name).to_sym
 
           if obj.is_a? Hash
-            attr_val = obj[k]
+            attr_val = obj.fetch(k, attr.options[:default])
           elsif obj.class <= Base # cannot use is_a?
             begin
               attr_val = obj.send(k)

--- a/spec/erlen/schema/base_spec.rb
+++ b/spec/erlen/schema/base_spec.rb
@@ -106,6 +106,11 @@ describe Erlen::Schema::Base do
       expect(payload.foo).to eq('bar')
       expect(payload.custom).to eq(nil)
     end
+
+    it 'defaults hash attributes' do
+      payload = TestBaseSchema.import(foo: 'bar', custom: 1)
+      expect(payload.default).to eq(10)
+    end
   end
 
   describe '#to_data' do
@@ -199,6 +204,7 @@ end
 class TestBaseSchema < Erlen::Schema::Base
   attribute :foo, String, { alias: :bar }
   attribute :custom, Integer
+  attribute :default, Integer, default: 10
 
   validate("Error Message") { |s| s.foo == 'bar' || s.foo == 1 }
 end


### PR DESCRIPTION
The test example below initially didn't work, but will now.
```ruby
class Foo < Erlen::Schema::Base
   attribute :bar, Integer, default: 10
 end

 :029 > Foo.import({}).bar
 => nil
```