### PR TITLE
Add to_markdown to Schema Base

### DIFF
--- a/lib/erlen/schema/base.rb
+++ b/lib/erlen/schema/base.rb
@@ -1,3 +1,5 @@
+require_relative './documentation'
+
 module Erlen; module Schema
   # This class is the basis for all schemas. If a schema class inherits this
   # class, it's ready to define attributes. When a schema class inherits
@@ -12,6 +14,7 @@ module Erlen; module Schema
   #       prefix to avoid conflicts with attribute names that may be defined
   #       later by the user.
   class Base
+    extend ::Erlen::Schema::Documentation
 
     # List of error messages
     attr_accessor :errors

--- a/lib/erlen/schema/documentation.rb
+++ b/lib/erlen/schema/documentation.rb
@@ -1,0 +1,92 @@
+module Erlen; module Schema
+  module Documentation
+    #
+    #
+    #
+    # @return a string in markdown representing the schema
+    def to_markdown
+      name = self.name.demodulize.gsub('Schema', '')
+      result = ["## #{name}", '', '> Example Response', '', '```json', '']
+
+      # JSON EXAMPLE
+      result.concat(example_value(self))
+
+      result << '```'
+
+      result.concat(class_attributes(self))
+      result.join("\n")
+    end
+
+    def example_value(schema_klass, indentation=2)
+      result = []
+      result << '{'
+
+      attr_count = 1
+      total_count = schema_klass.schema_attributes.count
+      schema_klass.schema_attributes.each do |attr_name, attr|
+        comma = attr_count == total_count ? '' : ','
+        result << "#{' ' * indentation}\"#{attr_name}\" : #{example_attr_value(attr.type, attr.name, indentation)}#{comma}"
+        attr_count += 1
+      end
+
+      result << "#{' ' * (indentation - 2)}}"
+      result
+    end
+
+    def example_attr_value(attr_type, attr_name, indentation)
+      if attr_type == Integer
+        rand(100)
+      elsif attr_type == String
+        "\"#{attr_name.titleize.upcase}\""
+      elsif [Time, Date].include? attr_type
+        "\"#{Time.current}\""
+      elsif attr_type == Boolean
+        rand(2) == 1
+      elsif attr_type < Base && attr_type.respond_to?(:element_type)
+        val = example_attr_value(attr_type.element_type, attr_name, indentation + 2)
+        [
+          '[',
+          "#{' ' * (indentation + 2)}#{val}",
+          "#{' ' * indentation}]"
+        ].join("\n")
+      elsif attr_type < Base
+        example_value(attr_type, indentation + 2).join("\n")
+      else
+        {}
+      end
+    end
+
+    def class_attributes(klass)
+      types = []
+      result = [
+        '',
+        'Attributes | Type | Required | Description',
+        '---------- | ---- | -------- | -----------'
+      ]
+
+      klass.schema_attributes.each do |attr_name, attr|
+        if attr.type.respond_to?(:element_type)
+          type_name = attr.type.element_type.name.demodulize.gsub('Schema', '').titleize
+          result << "#{attr_name} | Array of #{type_name} | #{attr.options[:required]} | "
+          types << attr.type.element_type if (attr.type.element_type < Base)
+        elsif attr.type < Base
+          type_name = attr.type.name.demodulize.gsub('Schema', '').titleize
+          result << "#{attr_name} | #{type_name} | #{attr.options[:required]} | "
+          types << attr.type
+        else
+          result << "#{attr_name} | #{attr.type} | #{attr.options[:required]} | "
+        end
+      end
+
+      types.each do |t|
+        result << ''
+        result << "## #{t.name.demodulize.gsub('Schema', '')}"
+        result << ''
+
+        result.concat(class_attributes(t))
+      end
+
+      result
+    end
+  end
+end; end

--- a/lib/erlen/schema/documentation.rb
+++ b/lib/erlen/schema/documentation.rb
@@ -39,7 +39,7 @@ module Erlen; module Schema
       elsif attr_type == String
         "\"#{attr_name.titleize.upcase}\""
       elsif [Time, Date].include? attr_type
-        "\"#{Time.current}\""
+        "\"#{Time.now}\""
       elsif attr_type == Boolean
         rand(2) == 1
       elsif attr_type < Base && attr_type.respond_to?(:element_type)


### PR DESCRIPTION
Outputs a string that can be used as markdown documentation for an API endpoint.