### PR TITLE
Adds support for checking if a value was explicitly provided

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    erlen (0.1.10)
+    erlen (0.1.11)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/erlen/schema/base.rb
+++ b/lib/erlen/schema/base.rb
@@ -60,7 +60,11 @@ module Erlen; module Schema
           obj_attribute_name = (attr.options[:alias] || attr.name).to_sym
 
           if obj.is_a? Hash
-            attr_val = obj.fetch(k, attr.options[:default])
+            if obj.has_key?(k) || attr.options.has_key?(:default)
+              attr_val = obj.fetch(k, attr.options[:default])
+            else
+              attr_val = Undefined.new
+            end
           elsif obj.class <= Base # cannot use is_a?
             begin
               attr_val = obj.send(k)

--- a/lib/erlen/schema/base.rb
+++ b/lib/erlen/schema/base.rb
@@ -138,6 +138,16 @@ module Erlen; module Schema
       __validate_payload
     end
 
+    # Determine whether the payload was provided the value.
+    # This is an effective way to distinguish between an
+    # explicitly set nil value and a value that wasn't provided
+    #
+    # @return [Boolean]
+    def attribute_provided?(name)
+      __has_attribute(name) &&
+        !@attributes[name].is_a?(Erlen::Undefined)
+    end
+
     # Determines if the payload is an instance of the specified schema
     # class. This overrides Object#is_a? so subclassing is not considered
     # true. The logic is actually implemented in ::Base.schema_of?:: method

--- a/lib/erlen/version.rb
+++ b/lib/erlen/version.rb
@@ -1,3 +1,3 @@
 module Erlen
-  VERSION = '0.1.10'.freeze
+  VERSION = '0.1.11'.freeze
 end

--- a/spec/erlen/schema/base_spec.rb
+++ b/spec/erlen/schema/base_spec.rb
@@ -71,6 +71,48 @@ describe Erlen::Schema::Base do
     end
   end
 
+  describe "#attribute_provided?" do
+    it "returns true when a value is provided" do
+      schema = TestBaseSchema.new({ foo: 'bar' })
+      expect(schema.attribute_provided?(:foo)).to be_truthy
+
+      schema = TestBaseSchema.import({ foo: 'bar' })
+      expect(schema.attribute_provided?(:foo)).to be_truthy
+    end
+
+    it "returns true even when the provided value is nil" do
+      schema = TestBaseSchema.new({ foo: nil })
+      expect(schema.attribute_provided?(:foo)).to be_truthy
+
+      schema = TestBaseSchema.import({ foo: nil })
+      expect(schema.attribute_provided?(:foo)).to be_truthy
+    end
+
+    it "returns true when a default value is set" do
+      schema = TestBaseSchema.new({})
+      expect(schema.attribute_provided?(:default)).to be_truthy
+
+      schema = TestBaseSchema.import({})
+      expect(schema.attribute_provided?(:default)).to be_truthy
+    end
+
+    it "returns false for unknown values" do
+      schema = TestBaseSchema.new({ foo: 'bar' })
+      expect(schema.attribute_provided?(:baz)).to be_falsey
+
+      schema = TestBaseSchema.import({ foo: 'bar' })
+      expect(schema.attribute_provided?(:baz)).to be_falsey
+    end
+
+    it "returns false when a known value is not provided" do
+      schema = TestBaseSchema.new({ foo: 'bar' })
+      expect(schema.attribute_provided?(:custom)).to be_falsey
+
+      schema = TestBaseSchema.import({ foo: 'bar' })
+      expect(schema.attribute_provided?(:custom)).to be_falsey
+    end
+  end
+
   describe "#method_missing" do
     it "sets and gets attribute by method" do
       missing = TestBaseSchema.new({ foo: 'NOT' })


### PR DESCRIPTION
The use-case for this is handling situations where a nil value was provided on purpose (i.e. nil isn't the absence of something, but an explicit state).

```ruby
class FooSchema < Erlen::Schema::Base
  attribute :foo, Integer
end

FooSchema.import({}).attribute_provided?(:foo) # => false
FooSchema.import({ foo: nil }).attribute_provided?(:foo) # => true

FooSchema.new({}).attribute_provided?(:foo) # => false
FooSchema.new({ foo: nil }).attribute_provided?(:foo) # => true

```