### PR TITLE
Context for serializing through import.

### DIFF
--- a/lib/erlen/schema/base.rb
+++ b/lib/erlen/schema/base.rb
@@ -53,8 +53,8 @@ module Erlen; module Schema
       #
       # @param obj [Object] any object
       # @return Base the concrete schema object.
-      def import(obj)
-        payload = self.new
+      def import(obj, context={})
+        payload = new
 
         schema_attributes.each_pair do |k, attr|
           obj_attribute_name = (attr.options[:alias] || attr.name).to_sym
@@ -76,7 +76,9 @@ module Erlen; module Schema
               attr_val = attr.options.include?(:default) ? attr.options[:default] : Undefined.new
             end
           elsif obj.respond_to?(obj_attribute_name)
-            attr_val = obj.send(obj_attribute_name)
+            method = obj.method(obj_attribute_name)
+
+            attr_val = method.arity == 1 ? method.call(context) : method.call
           else
             attr_val = attr.options.include?(:default) ? attr.options[:default] : Undefined.new
           end
@@ -273,7 +275,7 @@ module Erlen; module Schema
       !__find_attribute_name(name).nil?
     end
 
-    def __assign_attribute(name, value)
+    def __assign_attribute(name, value, context={})
       name = name.to_sym
       raise(NoAttributeError, name) unless __has_assignable_attribute(name)
 

--- a/lib/erlen/schema/base.rb
+++ b/lib/erlen/schema/base.rb
@@ -83,7 +83,7 @@ module Erlen; module Schema
             attr_val = attr.options.include?(:default) ? attr.options[:default] : Undefined.new
           end
 
-          attr_val = attr.type.import(attr_val) if attr.type <= Base
+          attr_val = attr.type.import(attr_val, context) if attr.type <= Base
 
           # private method so use send
           payload.send(:__assign_attribute, k, attr_val)
@@ -275,7 +275,7 @@ module Erlen; module Schema
       !__find_attribute_name(name).nil?
     end
 
-    def __assign_attribute(name, value, context={})
+    def __assign_attribute(name, value)
       name = name.to_sym
       raise(NoAttributeError, name) unless __has_assignable_attribute(name)
 

--- a/spec/erlen/schema/base_spec.rb
+++ b/spec/erlen/schema/base_spec.rb
@@ -58,6 +58,8 @@ describe Erlen::Schema::Base do
       expect(payload.bool2).to eq(false)
       expect(payload.dt).to eq(DateTime.parse('1/1/2017'))
       expect(payload.d).to eq(Date.parse('2018-02-03'))
+=======
+>>>>>>> 3b5369b... Uses rails parameters and coerces attr type value
     end
   end
 

--- a/spec/erlen/schema/base_spec.rb
+++ b/spec/erlen/schema/base_spec.rb
@@ -58,8 +58,6 @@ describe Erlen::Schema::Base do
       expect(payload.bool2).to eq(false)
       expect(payload.dt).to eq(DateTime.parse('1/1/2017'))
       expect(payload.d).to eq(Date.parse('2018-02-03'))
-=======
->>>>>>> 3b5369b... Uses rails parameters and coerces attr type value
     end
   end
 

--- a/spec/erlen/schema/base_spec.rb
+++ b/spec/erlen/schema/base_spec.rb
@@ -171,6 +171,12 @@ describe Erlen::Schema::Base do
       payload = TestBaseSchema.import(foo: 'bar', custom: 1)
       expect(payload.default).to eq(10)
     end
+
+    it 'imports from an obj with context' do
+      payload = TestContextSchema.import(TestObj.new, con: 'text')
+
+      expect(payload.with_arg).to eq('text')
+    end
   end
 
   describe '#to_data' do
@@ -284,7 +290,15 @@ class TestObj
   def bar
     'bar'
   end
+
+  def with_arg(opts)
+    opts[:con]
+  end
 end
 
 class TestSubSchema < TestBaseSchema
+end
+
+class TestContextSchema < TestBaseSchema
+  attribute :with_arg, String
 end


### PR DESCRIPTION
The idea behind the PR would be that in some cases the object itself is insufficient to directly serialize the object. This way we can provide context to the serialization that the method could use to be more robust. There are some specific examples in our app where current_user and current_organization would make things easier.

The problem I potentially see with this is that the method itself is unclear with what is being passed in and there isn't validation into what goes in.