### PR TITLE
Allow import to accept hashes with string keys

### DIFF
--- a/lib/erlen/schema/base.rb
+++ b/lib/erlen/schema/base.rb
@@ -60,8 +60,12 @@ module Erlen; module Schema
           obj_attribute_name = (attr.options[:alias] || attr.name).to_sym
 
           if obj.is_a? Hash
-            if obj.has_key?(k) || attr.options.has_key?(:default)
-              attr_val = obj.fetch(k, attr.options[:default])
+            if obj.key?(k)
+              attr_val = obj[k]
+            elsif obj.key?(k.to_s)
+              attr_val = obj[k.to_s]
+            elsif attr.options.key?(:default)
+              attr_val = attr.options[:default]
             else
               attr_val = Undefined.new
             end

--- a/spec/erlen/schema/base_spec.rb
+++ b/spec/erlen/schema/base_spec.rb
@@ -151,6 +151,13 @@ describe Erlen::Schema::Base do
       expect(payload.custom).to eq(1)
     end
 
+    it 'imports from a hash with string keys' do
+      payload = TestBaseSchema.import('foo' => 'bar', 'custom' => 1)
+
+      expect(payload.foo).to eq('bar')
+      expect(payload.custom).to eq(1)
+    end
+
     it 'imports from an obj' do
       payload = TestBaseSchema.import(TestObj.new)
 


### PR DESCRIPTION
This PR allows schemas to import from a hash that is keyed with strings. Previously, import would only accept hashes with symbol keys or ones that allowed for indifferent access (e.g., by calling the Rails extension `hash.with_indifferent_access`.)