### PR TITLE
Fixes for context on import

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    erlen (0.1.11)
+    erlen (0.1.12)
 
 GEM
   remote: https://rubygems.org/
@@ -88,4 +88,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/lib/erlen/schema/any_of.rb
+++ b/lib/erlen/schema/any_of.rb
@@ -22,9 +22,9 @@ module Erlen; module Schema
             "AnyOf#{self.allowed_schemas.map {|s| s.name}.join("Or")}"
           end
 
-          def import(obj)
-            schema = allowed_schemas.find do |s| s.import(obj).valid? end
-            payload = schema.import(obj) if schema
+          def import(obj, context={})
+            schema = allowed_schemas.find { |s| s.import(obj, context).valid? }
+            payload = schema.import(obj, context) if schema
             hash = payload.to_data if payload
             new(hash)
           end

--- a/lib/erlen/schema/array_of.rb
+++ b/lib/erlen/schema/array_of.rb
@@ -132,7 +132,7 @@ module Erlen; module Schema
           #
           # @param array of objs [Object] any objects
           # @return Base the concrete schema object.
-          def import(obj_elements)
+          def import(obj_elements, context={})
             payload = self.new
 
             if obj_elements.class <= Base && obj_elements.class.respond_to?(:element_type)
@@ -142,7 +142,7 @@ module Erlen; module Schema
             end
 
             obj_elements.each do |obj|
-              payload << obj
+              payload << payload.send(:normalize_element, obj, context)
             end
 
             payload
@@ -263,12 +263,12 @@ module Erlen; module Schema
 
         def elements; @elements end
 
-        def normalize_element(element)
+        def normalize_element(element, context={})
           if self.class.element_type <= Base && element.is_a?(Hash)
             self.class.element_type.new(element)
 
           elsif self.class.element_type <= Base && !(element.class <= Base)
-            self.class.element_type.import(element)
+            self.class.element_type.import(element, context)
 
           else
             element

--- a/lib/erlen/schema/array_of.rb
+++ b/lib/erlen/schema/array_of.rb
@@ -142,7 +142,7 @@ module Erlen; module Schema
             end
 
             obj_elements.each do |obj|
-              payload << payload.send(:normalize_element, obj, context)
+              payload << payload.send(:normalize_element_import, obj, context)
             end
 
             payload
@@ -263,12 +263,20 @@ module Erlen; module Schema
 
         def elements; @elements end
 
-        def normalize_element(element, context={})
+        def normalize_element_import(element, context={})
+          if self.class.element_type <= Base && !(element.class <= Base)
+            self.class.element_type.import(element, context)
+          else
+            element
+          end
+        end
+
+        def normalize_element(element)
           if self.class.element_type <= Base && element.is_a?(Hash)
             self.class.element_type.new(element)
 
           elsif self.class.element_type <= Base && !(element.class <= Base)
-            self.class.element_type.import(element, context)
+            self.class.element_type.import(element)
 
           else
             element

--- a/lib/erlen/version.rb
+++ b/lib/erlen/version.rb
@@ -1,3 +1,3 @@
 module Erlen
-  VERSION = '0.1.11'.freeze
+  VERSION = '0.1.12'.freeze
 end

--- a/spec/erlen/schema/array_of_spec.rb
+++ b/spec/erlen/schema/array_of_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Erlen::Schema::ArrayOf do
+  subject { described_class.new(TestArraySchema) }
+
+  describe 'import' do
+    it 'imports hashes into the base schema' do
+      payload = subject.import(
+        [
+          { 'foo' => 'bar', custom: 1, other: true },
+          { 'foo' => 'baz', custom: 2, 'something else' => false }
+        ]
+      )
+
+      expect(payload.valid?).to be_truthy
+      expect(payload[0].foo).to eq('bar')
+      expect(payload[0].custom).to eq(1)
+      expect(payload[1].foo).to eq('baz')
+      expect(payload[1].custom).to eq(2)
+    end
+  end
+
+  describe 'new' do
+    it 'creates from hashes as expected' do
+      payload = subject.new(
+        [
+          { 'foo' => 'bar', custom: 1 },
+          { 'foo' => 'baz', custom: 2 }
+        ]
+      )
+
+      expect(payload.valid?).to be_truthy
+      expect(payload[0].foo).to eq('bar')
+      expect(payload[0].custom).to eq(1)
+      expect(payload[1].foo).to eq('baz')
+      expect(payload[1].custom).to eq(2)
+    end
+
+    it 'strictly interpets hashes' do
+      expect do
+        subject.new([{ 'foo' => 'bar', other_value: 'fail' }])
+      end.to raise_error(Erlen::NoAttributeError)
+    end
+  end
+end
+
+class TestArraySchema < Erlen::Schema::Base
+  attribute :foo, String
+  attribute :custom, Integer
+end


### PR DESCRIPTION
I wish I had an interface to enforce imports method signature. Alas, Ruby