### PR TITLE
Make ArrayOf use import if import was used on it

### DIFF
--- a/lib/erlen/schema/array_of.rb
+++ b/lib/erlen/schema/array_of.rb
@@ -142,7 +142,7 @@ module Erlen; module Schema
             end
 
             obj_elements.each do |obj|
-              payload << payload.send(:normalize_element, obj, context)
+              payload << payload.send(:normalize_element_import, obj, context)
             end
 
             payload
@@ -263,12 +263,20 @@ module Erlen; module Schema
 
         def elements; @elements end
 
-        def normalize_element(element, context={})
+        def normalize_element_import(element, context={})
+          if self.class.element_type <= Base && !(element.class <= Base)
+            self.class.element_type.import(element, context)
+          else
+            element
+          end
+        end
+
+        def normalize_element(element)
           if self.class.element_type <= Base && element.is_a?(Hash)
             self.class.element_type.new(element)
 
           elsif self.class.element_type <= Base && !(element.class <= Base)
-            self.class.element_type.import(element, context)
+            self.class.element_type.import(element)
 
           else
             element

--- a/spec/erlen/schema/array_of_spec.rb
+++ b/spec/erlen/schema/array_of_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Erlen::Schema::ArrayOf do
+  subject { described_class.new(TestArraySchema) }
+
+  describe 'import' do
+    it 'imports hashes into the base schema' do
+      payload = subject.import(
+        [
+          { 'foo' => 'bar', custom: 1, other: true },
+          { 'foo' => 'baz', custom: 2, 'something else' => false }
+        ]
+      )
+
+      expect(payload.valid?).to be_truthy
+      expect(payload[0].foo).to eq('bar')
+      expect(payload[0].custom).to eq(1)
+      expect(payload[1].foo).to eq('baz')
+      expect(payload[1].custom).to eq(2)
+    end
+  end
+
+  describe 'new' do
+    it 'creates from hashes as expected' do
+      payload = subject.new(
+        [
+          { 'foo' => 'bar', custom: 1 },
+          { 'foo' => 'baz', custom: 2 }
+        ]
+      )
+
+      expect(payload.valid?).to be_truthy
+      expect(payload[0].foo).to eq('bar')
+      expect(payload[0].custom).to eq(1)
+      expect(payload[1].foo).to eq('baz')
+      expect(payload[1].custom).to eq(2)
+    end
+
+    it 'strictly interpets hashes' do
+      expect do
+        subject.new([{ 'foo' => 'bar', other_value: 'fail' }])
+      end.to raise_error(Erlen::NoAttributeError)
+    end
+  end
+end
+
+class TestArraySchema < Erlen::Schema::Base
+  attribute :foo, String
+  attribute :custom, Integer
+end


### PR DESCRIPTION
This PR will force `ArrayOf.import` to call upon `element_type.import` for hashes, instead of using `new` which has different enforcement standards.