### PR TITLE
Array improvements

### DIFF
--- a/lib/erlen/schema/attribute.rb
+++ b/lib/erlen/schema/attribute.rb
@@ -59,7 +59,7 @@ module Erlen; module Schema
         raise ValidationError.new("#{name}: #{value} is not #{type.name}")
       end
 
-      if !validation.nil? && !validation.call(value)
+      if !validation.nil? && !validation.call(value.is_a?(Undefined) ? nil : value)
         raise ValidationError.new("#{name} is not valid")
       end
     end

--- a/lib/erlen/schema/base.rb
+++ b/lib/erlen/schema/base.rb
@@ -34,9 +34,23 @@ module Erlen; module Schema
       # @param type [Class] it must be either a primitive type or a
       #                     Base class.
       # @param opts [Hash, nil] options
-      # @param validation [Proc, nil] optinal validation block.
+      # @param validation [Proc, nil] optional validation block.
       def attribute(name, type, opts={}, &validation)
         attr = Attribute.new(name.to_sym, type, opts, &validation)
+        schema_attributes[name.to_sym] = attr
+      end
+
+      # Defines a collection for the schema. Must specify the type. If
+      # validation block is specified, the block will be executed at
+      # validation.
+      #
+      # @param name [Symbol] the name of attribute
+      # @param type [Class] class of array elements, it must be either a
+      #                     primitive type or a Base class.
+      # @param opts [Hash, nil] options
+      # @param validation [Proc, nil] optional validation block.
+      def collection(name, array_type, opts={}, &validation)
+        attr = Attribute.new(name.to_sym, ArrayOf.new(array_type), opts, &validation)
         schema_attributes[name.to_sym] = attr
       end
 
@@ -97,6 +111,27 @@ module Erlen; module Schema
         end
 
         payload
+      end
+
+      # Expects an array of objects and will wrap current class in ArrayOf and
+      # return payload.
+      #
+      # @param obj [Array] array of objects or hashes
+      # @param context [Hash] hash of objects providing context for functions
+      # @return Base the concrete schema object.
+      def import_array(obj_array, context={})
+        ArrayOf.new(self).import(obj_array, context)
+      end
+
+      # Expects an array of objects and will wrap current class in ArrayOf and
+      # return payload. Uses the new function to initialize object so will be more
+      # stringent on data requirements.
+      #
+      # @param obj [Array] array of objects or hashes
+      # @param context [Hash] hash of objects providing context for functions
+      # @return Base the concrete schema object.
+      def new_array(obj_array)
+        ArrayOf.new(self).new(obj_array)
       end
 
       def inherited(klass)

--- a/lib/erlen/schema/base.rb
+++ b/lib/erlen/schema/base.rb
@@ -35,7 +35,7 @@ module Erlen; module Schema
       #                     Base class.
       # @param opts [Hash, nil] options
       # @param validation [Proc, nil] optional validation block.
-      def attribute(name, type, opts={}, &validation)
+      def attribute(name, type, opts = {}, &validation)
         attr = Attribute.new(name.to_sym, type, opts, &validation)
         schema_attributes[name.to_sym] = attr
       end
@@ -49,9 +49,8 @@ module Erlen; module Schema
       #                     primitive type or a Base class.
       # @param opts [Hash, nil] options
       # @param validation [Proc, nil] optional validation block.
-      def collection(name, array_type, opts={}, &validation)
-        attr = Attribute.new(name.to_sym, ArrayOf.new(array_type), opts, &validation)
-        schema_attributes[name.to_sym] = attr
+      def collection(name, array_type, opts = {}, &validation)
+        attribute(name, ArrayOf.new(array_type), opts, &validation)
       end
 
       # Defines a custom validation block. Must specify message which is

--- a/spec/erlen/schema/array_of_spec.rb
+++ b/spec/erlen/schema/array_of_spec.rb
@@ -1,11 +1,9 @@
 require 'spec_helper'
 
 describe Erlen::Schema::ArrayOf do
-  subject { described_class.new(TestArraySchema) }
-
   describe 'import' do
     it 'imports hashes into the base schema' do
-      payload = subject.import(
+      payload = TestArraySchema.import_array(
         [
           { 'foo' => 'bar', custom: 1, other: true },
           { 'foo' => 'baz', custom: 2, 'something else' => false }
@@ -22,7 +20,7 @@ describe Erlen::Schema::ArrayOf do
 
   describe 'new' do
     it 'creates from hashes as expected' do
-      payload = subject.new(
+      payload = TestArraySchema.new_array(
         [
           { 'foo' => 'bar', custom: 1 },
           { 'foo' => 'baz', custom: 2 }
@@ -38,7 +36,7 @@ describe Erlen::Schema::ArrayOf do
 
     it 'strictly interpets hashes' do
       expect do
-        subject.new([{ 'foo' => 'bar', other_value: 'fail' }])
+        TestArraySchema.new_array([{ 'foo' => 'bar', other_value: 'fail' }])
       end.to raise_error(Erlen::NoAttributeError)
     end
   end

--- a/spec/erlen/schema/base_spec.rb
+++ b/spec/erlen/schema/base_spec.rb
@@ -1,5 +1,42 @@
 require 'spec_helper'
 
+class TestBaseSchema < Erlen::Schema::Base
+  attribute :foo, String, { alias: :bar }
+  attribute :custom, Integer
+  attribute :default, Integer, default: 10
+  collection :coll_attr, String
+
+  validate("Error Message") { |s| s.foo == 'bar' || s.foo == 1 }
+end
+
+class TestTypeSchema < Erlen::Schema::Base
+  attribute :int, Integer
+  attribute :flt, Float
+  attribute :bool, Boolean
+  attribute :bool2, Boolean
+  attribute :bool3, Boolean
+  attribute :bool4, Boolean
+  attribute :dt, DateTime
+  attribute :d, Date
+end
+
+class TestObj
+  def bar
+    'bar'
+  end
+
+  def with_arg(opts)
+    opts[:con]
+  end
+end
+
+class TestSubSchema < TestBaseSchema
+end
+
+class TestContextSchema < TestBaseSchema
+  attribute :with_arg, String
+end
+
 describe Erlen::Schema::Base do
   subject { described_class }
 
@@ -192,6 +229,28 @@ describe Erlen::Schema::Base do
     end
   end
 
+  describe '#import_array' do
+    it 'takes in an array and returns a payload' do
+      payload = TestBaseSchema.import_array([TestObj.new])
+
+      expect(payload.class.element_type).to eq(TestBaseSchema)
+
+      data = payload.to_data
+      expect(data[0]['foo']).to eq('bar')
+    end
+  end
+
+  describe '#new_array' do
+    it 'takes in an array and returns a payload' do
+      payload = TestBaseSchema.new_array([TestObj.new])
+
+      expect(payload.class.element_type).to be(TestBaseSchema)
+
+      data = payload.to_data
+      expect(data[0]['foo']).to eq('bar')
+    end
+  end
+
   describe '#to_data' do
     it 'converts to hash' do
       payload = TestBaseSchema.import(TestObj.new)
@@ -210,10 +269,20 @@ describe Erlen::Schema::Base do
     end
 
     it 'does not include undefined attribute' do
-      payload = TestBaseSchema.new()
+      payload = TestBaseSchema.new
       data = payload.to_data
       expect(data.include?('foo')).to be_falsey
       expect(data.include?('custom')).to be_falsey
+    end
+  end
+
+  describe 'collection' do
+    it 'initializes the attribute as an array' do
+      payload = TestBaseSchema.import(coll_attr: %w[foo bar])
+      data = payload.to_data
+
+      expect(data['coll_attr']).to include('foo')
+      expect(data['coll_attr']).to include('bar')
     end
   end
 
@@ -268,7 +337,12 @@ describe Erlen::Schema::Base do
       payload = TestBaseSchema.import(foo: 'bar', custom: 1)
 
       expect(payload).not_to receive(:warn)
-      expect(payload.as_json).to eq('foo' => 'bar', 'custom' => 1, 'default' => 10)
+      expect(payload.as_json).to eq(
+        'foo' => 'bar',
+        'custom' => 1,
+        'default' => 10,
+        'coll_attr' => [],
+      )
     end
 
     it 'filters by using activesupport Hash modifications' do
@@ -278,40 +352,4 @@ describe Erlen::Schema::Base do
       expect(payload.as_json(only: 'foo')).to eq('foo' => 'bar')
     end
   end
-end
-
-class TestBaseSchema < Erlen::Schema::Base
-  attribute :foo, String, { alias: :bar }
-  attribute :custom, Integer
-  attribute :default, Integer, default: 10
-
-  validate("Error Message") { |s| s.foo == 'bar' || s.foo == 1 }
-end
-
-class TestTypeSchema < Erlen::Schema::Base
-  attribute :int, Integer
-  attribute :flt, Float
-  attribute :bool, Boolean
-  attribute :bool2, Boolean
-  attribute :bool3, Boolean
-  attribute :bool4, Boolean
-  attribute :dt, DateTime
-  attribute :d, Date
-end
-
-class TestObj
-  def bar
-    'bar'
-  end
-
-  def with_arg(opts)
-    opts[:con]
-  end
-end
-
-class TestSubSchema < TestBaseSchema
-end
-
-class TestContextSchema < TestBaseSchema
-  attribute :with_arg, String
 end

--- a/spec/erlen/schema/base_spec.rb
+++ b/spec/erlen/schema/base_spec.rb
@@ -20,6 +20,10 @@ class TestTypeSchema < Erlen::Schema::Base
   attribute :d, Date
 end
 
+class TestCollectionSchema < Erlen::Schema::Base
+  collection :coll_attr, String, { required: true } { |p| p.count > 0 }
+end
+
 class TestObj
   def bar
     'bar'
@@ -283,6 +287,16 @@ describe Erlen::Schema::Base do
 
       expect(data['coll_attr']).to include('foo')
       expect(data['coll_attr']).to include('bar')
+    end
+
+    it 'runs collections validations' do
+      payload = TestCollectionSchema.import(coll_attr: [])
+      expect(payload.valid?).to be_falsey
+      expect(payload.errors).to eq(['coll_attr is not valid'])
+
+      payload = TestCollectionSchema.import({})
+      expect(payload.valid?).to be_falsey
+      expect(payload.errors).to eq(['coll_attr is not valid'])
     end
   end
 


### PR DESCRIPTION
The goal is to make it easier to work with arrays in schemas and payloads.
Previously you would do:
```
class Schema < Erlen::Schema::Base
  attribute some_array, ::Erlen::Schema::ArrayOf.new(BaseSchema)
end
::Erlen::Schema::ArrayOf.new(BaseSchema).new([...])
::Erlen::Schema::ArrayOf.new(BaseSchema).import([...])
```
After this PR you could do:
```
class Schema < Erlen::Schema::Base
  collection some_array, BaseSchema
end
BaseSchema.new_array([...])
BaseSchema.import_array([...])
```